### PR TITLE
#54 Enable Available Resources Via Variables in VPC Modules

### DIFF
--- a/aws/shared-vpc/test-instance.tf
+++ b/aws/shared-vpc/test-instance.tf
@@ -14,91 +14,9 @@ variable "test_ingress_cidr_block" {
   default = "10.0.0.0/8"
 }
 
-variable "kms_arn" {
-  type        = "string"
-  default     = "alias/parameter_store_key"
-  description = "The ARN of a KMS key used to encrypt and decrypt SecretString values"
-}
-
 # ----------------------------------------------------------------------------------------------------------------------
 # MODULES / RESOURCES
 # ----------------------------------------------------------------------------------------------------------------------
-
-# Create a default key/pair for public and private instances
-
-locals {
-  module_test_ssh_key_pair_public_tags = "${merge(local.tags, map(
-    "TerraformModule", "cloudposse/terraform-aws-key-pair",
-    "TerraformModuleVersion", "0.2.5"))}"
-}
-
-module "ssh_key_pair_public" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-key-pair.git?ref=0.2.5"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.environment}-${var.name}-public"
-  tags      = "${local.module_test_ssh_key_pair_public_tags}"
-
-  ssh_public_key_path   = "${pathexpand("~/.ssh")}/${var.namespace}"
-  generate_ssh_key      = "true"
-  private_key_extension = ".pem"
-  public_key_extension  = ".pub"
-  chmod_command         = "chmod 600 %v"
-}
-
-locals {
-  module_test_ssh_key_pair_private_tags = "${merge(local.tags, map(
-    "TerraformModule", "gravicore/terraform-gravicore-modules/aws/shared-vpc/key-pair",
-    "TerraformModuleVersion", "issues/4"))}"
-}
-
-module "ssh_key_pair_private" {
-  source    = "./key-pair"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.environment}-${var.name}-private"
-  tags      = "${local.module_test_ssh_key_pair_private_tags}"
-
-  ssh_public_key_path   = "${pathexpand("~/.ssh")}/${var.namespace}"
-  generate_ssh_key      = "true"
-  private_key_extension = ".pem"
-  public_key_extension  = ".pub"
-  chmod_command         = "chmod 600 %v"
-}
-
-locals {
-  test_ssh_ec2_instance_secret_ssm_write = [
-    {
-      name        = "/${local.stage_prefix}/${var.name}-test-pem"
-      value       = "${module.ssh_key_pair_private.private_key}"
-      type        = "SecureString"
-      overwrite   = "true"
-      description = "${join(" ", list(var.desc_prefix, "VPC Test SSH Instance Private Key"))}"
-    },
-    {
-      name        = "/${local.stage_prefix}/${var.name}-test-pub"
-      value       = "${module.ssh_key_pair_private.public_key}"
-      type        = "SecureString"
-      overwrite   = "true"
-      description = "${join(" ", list(var.desc_prefix, "VPC Test SSH Instance Public Key"))}"
-    },
-  ]
-
-  # `test_ssh_ec2_instance_secret_ssm_write_count` needs to be updated if `test_ssh_ec2_instance_secret_ssm_write` changes
-  test_ssh_ec2_instance_secret_ssm_write_count = 2
-}
-
-resource "aws_ssm_parameter" "default" {
-  count           = "${var.create_test_instance == "true" ? local.test_ssh_ec2_instance_secret_ssm_write_count : 0}"
-  name            = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "name")}"
-  description     = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "description", lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "name"))}"
-  type            = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "type", "SecureString")}"
-  key_id          = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""}"
-  value           = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "value")}"
-  overwrite       = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "overwrite", "false")}"
-  allowed_pattern = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "allowed_pattern", "")}"
-  tags            = "${local.tags}"
-}
 
 locals {
   module_test_ssh_sg_tags = "${merge(local.tags, map(

--- a/aws/shared-vpc/vpc.tf
+++ b/aws/shared-vpc/vpc.tf
@@ -195,7 +195,7 @@ resource "aws_ssm_parameter" "default" {
 locals {
   module_vpc_tags = "${merge(local.tags, map(
     "TerraformModule", "terraform-aws-modules/terraform-aws-vpc",
-    "TerraformModuleVersion", "v1.46.0"))}"
+    "TerraformModuleVersion", "v1.66.0"))}"
 }
 
 module "vpc" {

--- a/aws/shared-vpc/vpc.tf
+++ b/aws/shared-vpc/vpc.tf
@@ -6,9 +6,191 @@ variable "cidr_network" {
   default = "10.0"
 }
 
+variable "kms_arn" {
+  type        = "string"
+  default     = "alias/parameter_store_key"
+  description = "The ARN of a KMS key used to encrypt and decrypt SecretString values"
+}
+
+variable "map_public_ip_on_launch" {
+  description = "Should be false if you do not want to auto-assign public IP on launch"
+  default     = false
+}
+
+variable "enable_nat_gateway" {
+  description = "Should be true if you want to provision NAT Gateways for each of your private networks"
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  description = "Should be true if you want to provision a single shared NAT Gateway across all of your private networks"
+  default     = false
+}
+
+variable "one_nat_gateway_per_az" {
+  description = "Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`."
+  default     = false
+}
+
+variable "enable_dynamodb_endpoint" {
+  description = "Should be true if you want to provision a DynamoDB endpoint to the VPC"
+  default     = true
+}
+
+variable "enable_s3_endpoint" {
+  description = "Should be true if you want to provision an S3 endpoint to the VPC"
+  default     = true
+}
+
+variable "enable_sqs_endpoint" {
+  description = "Should be true if you want to provision an SQS endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ssm_endpoint" {
+  description = "Should be true if you want to provision an SSM endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ssmmessages_endpoint" {
+  description = "Should be true if you want to provision a SSMMESSAGES endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_apigw_endpoint" {
+  description = "Should be true if you want to provision an api gateway endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ec2_endpoint" {
+  description = "Should be true if you want to provision an EC2 endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ec2messages_endpoint" {
+  description = "Should be true if you want to provision an EC2MESSAGES endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecr_api_endpoint" {
+  description = "Should be true if you want to provision an ecr api endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecr_dkr_endpoint" {
+  description = "Should be true if you want to provision an ecr dkr endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_kms_endpoint" {
+  description = "Should be true if you want to provision a KMS endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecs_endpoint" {
+  description = "Should be true if you want to provision a ECS endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecs_agent_endpoint" {
+  description = "Should be true if you want to provision a ECS Agent endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecs_telemetry_endpoint" {
+  description = "Should be true if you want to provision a ECS Telemetry endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_dns_hostnames" {
+  description = "Should be true to enable DNS hostnames in the VPC"
+  default     = true
+}
+
+variable "enable_dns_support" {
+  description = "Should be true to enable DNS support in the VPC"
+  default     = true
+}
+
 # ----------------------------------------------------------------------------------------------------------------------
 # MODULES / RESOURCES
 # ----------------------------------------------------------------------------------------------------------------------
+
+# Create a default key/pair for public and private instances
+
+locals {
+  module_ssh_key_pair_public_tags = "${merge(local.tags, map(
+    "TerraformModule", "cloudposse/terraform-aws-key-pair",
+    "TerraformModuleVersion", "0.2.5"))}"
+}
+
+module "ssh_key_pair_public" {
+  source    = "git::https://github.com/cloudposse/terraform-aws-key-pair.git?ref=0.2.5"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.environment}-${var.name}-public"
+  tags      = "${local.module_ssh_key_pair_public_tags}"
+
+  ssh_public_key_path   = "${pathexpand("~/.ssh")}/${var.namespace}"
+  generate_ssh_key      = "${var.create}"
+  private_key_extension = ".pem"
+  public_key_extension  = ".pub"
+  chmod_command         = "chmod 600 %v"
+}
+
+locals {
+  module_ssh_key_pair_private_tags = "${merge(local.tags, map(
+    "TerraformModule", "gravicore/terraform-gravicore-modules/aws/shared-vpc/key-pair",
+    "TerraformModuleVersion", "issues/4"))}"
+}
+
+module "ssh_key_pair_private" {
+  source    = "./key-pair"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.environment}-${var.name}-private"
+  tags      = "${local.module_ssh_key_pair_private_tags}"
+
+  ssh_public_key_path   = "${pathexpand("~/.ssh")}/${var.namespace}"
+  generate_ssh_key      = "${var.create}"
+  private_key_extension = ".pem"
+  public_key_extension  = ".pub"
+  chmod_command         = "chmod 600 %v"
+}
+
+locals {
+  ssh_secret_ssm_write = [
+    {
+      name        = "/${local.stage_prefix}/${var.name}-private-pem"
+      value       = "${module.ssh_key_pair_private.private_key}"
+      type        = "SecureString"
+      overwrite   = "true"
+      description = "${join(" ", list(var.desc_prefix, "Private SSH Key for EC2 Instances in Private VPC Subnet"))}"
+    },
+    {
+      name        = "/${local.stage_prefix}/${var.name}-private-pub"
+      value       = "${module.ssh_key_pair_private.public_key}"
+      type        = "SecureString"
+      overwrite   = "true"
+      description = "${join(" ", list(var.desc_prefix, "Public SSH Key for EC2 Instances in Private VPC Subnet"))}"
+    },
+  ]
+
+  # `ssh_secret_ssm_write_count` needs to be updated if `ssh_secret_ssm_write` changes
+  ssh_secret_ssm_write_count = 2
+}
+
+resource "aws_ssm_parameter" "default" {
+  count           = "${var.create == "true" ? local.ssh_secret_ssm_write_count : 0}"
+  name            = "${lookup(local.ssh_secret_ssm_write[count.index], "name")}"
+  description     = "${lookup(local.ssh_secret_ssm_write[count.index], "description", lookup(local.ssh_secret_ssm_write[count.index], "name"))}"
+  type            = "${lookup(local.ssh_secret_ssm_write[count.index], "type", "SecureString")}"
+  key_id          = "${lookup(local.ssh_secret_ssm_write[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""}"
+  value           = "${lookup(local.ssh_secret_ssm_write[count.index], "value")}"
+  overwrite       = "${lookup(local.ssh_secret_ssm_write[count.index], "overwrite", "false")}"
+  allowed_pattern = "${lookup(local.ssh_secret_ssm_write[count.index], "allowed_pattern", "")}"
+  tags            = "${local.tags}"
+}
 
 locals {
   module_vpc_tags = "${merge(local.tags, map(
@@ -17,21 +199,34 @@ locals {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.46.0"
+  source     = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.66.0"
   create_vpc = "${var.create == "true" ?  1 : 0}"
   name       = "${local.module_prefix}"
   tags       = "${local.module_vpc_tags}"
 
-  azs                      = ["${var.aws_region}a", "${var.aws_region}b"]
-  cidr                     = "${var.cidr_network}.0.0/16"
-  private_subnets          = ["${var.cidr_network}.0.0/19", "${var.cidr_network}.32.0/19"]
-  public_subnets           = ["${var.cidr_network}.128.0/20", "${var.cidr_network}.144.0/20"]
-  map_public_ip_on_launch  = false
-  enable_nat_gateway       = false
-  enable_dynamodb_endpoint = true
-  enable_s3_endpoint       = true
-  enable_dns_support       = true
-  enable_dns_hostnames     = true
+  azs                           = ["${var.aws_region}a", "${var.aws_region}b"]
+  cidr                          = "${var.cidr_network}.0.0/16"
+  private_subnets               = ["${var.cidr_network}.0.0/19", "${var.cidr_network}.32.0/19"]
+  public_subnets                = ["${var.cidr_network}.128.0/20", "${var.cidr_network}.144.0/20"]
+  map_public_ip_on_launch       = "${var.map_public_ip_on_launch}"
+  enable_nat_gateway            = "${var.enable_nat_gateway}"
+  single_nat_gateway            = "${var.single_nat_gateway}"
+  one_nat_gateway_per_az        = "${var.one_nat_gateway_per_az}"
+  enable_dynamodb_endpoint      = "${var.enable_dynamodb_endpoint}"
+  enable_s3_endpoint            = "${var.enable_s3_endpoint}"
+  enable_dns_support            = "${var.enable_dns_support}"
+  enable_dns_hostnames          = "${var.enable_dns_hostnames}"
+  enable_sqs_endpoint           = "${var.enable_sqs_endpoint}"
+  enable_ssm_endpoint           = "${var.enable_ssm_endpoint}"
+  enable_ssmmessages_endpoint   = "${var.enable_ssmmessages_endpoint}"
+  enable_apigw_endpoint         = "${var.enable_apigw_endpoint}"
+  enable_ec2_endpoint           = "${var.enable_ec2_endpoint}"
+  enable_ecr_api_endpoint       = "${var.enable_ecr_api_endpoint}"
+  enable_ecr_dkr_endpoint       = "${var.enable_ecr_dkr_endpoint}"
+  enable_kms_endpoint           = "${var.enable_kms_endpoint}"
+  enable_ecs_endpoint           = "${var.enable_ecs_endpoint}"
+  enable_ecs_agent_endpoint     = "${var.enable_ecs_agent_endpoint}"
+  enable_ecs_telemetry_endpoint = "${var.enable_ecs_telemetry_endpoint}"
 }
 
 resource "aws_vpc_dhcp_options_association" "vpc" {

--- a/aws/spoke-vpc/test-instance.tf
+++ b/aws/spoke-vpc/test-instance.tf
@@ -14,91 +14,9 @@ variable "test_ingress_cidr_block" {
   default = "10.0.0.0/8"
 }
 
-variable "kms_arn" {
-  type        = "string"
-  default     = "alias/parameter_store_key"
-  description = "The ARN of a KMS key used to encrypt and decrypt SecretString values"
-}
-
 # ----------------------------------------------------------------------------------------------------------------------
 # MODULES / RESOURCES
 # ----------------------------------------------------------------------------------------------------------------------
-
-# Create a default key/pair for public and private instances
-
-locals {
-  module_test_ssh_key_pair_public_tags = "${merge(local.tags, map(
-    "TerraformModule", "cloudposse/terraform-aws-key-pair",
-    "TerraformModuleVersion", "0.2.5"))}"
-}
-
-module "ssh_key_pair_public" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-key-pair.git?ref=0.2.5"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.environment}-${var.name}-public"
-  tags      = "${local.module_test_ssh_key_pair_public_tags}"
-
-  ssh_public_key_path   = "${pathexpand("~/.ssh")}/${var.namespace}"
-  generate_ssh_key      = "true"
-  private_key_extension = ".pem"
-  public_key_extension  = ".pub"
-  chmod_command         = "chmod 600 %v"
-}
-
-locals {
-  module_test_ssh_key_pair_private_tags = "${merge(local.tags, map(
-    "TerraformModule", "gravicore/terraform-gravicore-modules/aws/shared-vpc/key-pair",
-    "TerraformModuleVersion", "issues/4"))}"
-}
-
-module "ssh_key_pair_private" {
-  source    = "./key-pair"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.environment}-${var.name}-private"
-  tags      = "${local.module_test_ssh_key_pair_private_tags}"
-
-  ssh_public_key_path   = "${pathexpand("~/.ssh")}/${var.namespace}"
-  generate_ssh_key      = "true"
-  private_key_extension = ".pem"
-  public_key_extension  = ".pub"
-  chmod_command         = "chmod 600 %v"
-}
-
-locals {
-  test_ssh_ec2_instance_secret_ssm_write = [
-    {
-      name        = "/${local.stage_prefix}/${var.name}-test-pem"
-      value       = "${module.ssh_key_pair_private.private_key}"
-      type        = "SecureString"
-      overwrite   = "true"
-      description = "${join(" ", list(var.desc_prefix, "VPC Test SSH Instance Private Key"))}"
-    },
-    {
-      name        = "/${local.stage_prefix}/${var.name}-test-pub"
-      value       = "${module.ssh_key_pair_private.public_key}"
-      type        = "SecureString"
-      overwrite   = "true"
-      description = "${join(" ", list(var.desc_prefix, "VPC Test SSH Instance Public Key"))}"
-    },
-  ]
-
-  # `test_ssh_ec2_instance_secret_ssm_write_count` needs to be updated if `test_ssh_ec2_instance_secret_ssm_write` changes
-  test_ssh_ec2_instance_secret_ssm_write_count = 2
-}
-
-resource "aws_ssm_parameter" "default" {
-  count           = "${var.create_test_instance == "true" ? local.test_ssh_ec2_instance_secret_ssm_write_count : 0}"
-  name            = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "name")}"
-  description     = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "description", lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "name"))}"
-  type            = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "type", "SecureString")}"
-  key_id          = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""}"
-  value           = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "value")}"
-  overwrite       = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "overwrite", "false")}"
-  allowed_pattern = "${lookup(local.test_ssh_ec2_instance_secret_ssm_write[count.index], "allowed_pattern", "")}"
-  tags            = "${local.tags}"
-}
 
 locals {
   module_test_ssh_sg_tags = "${merge(local.tags, map(

--- a/aws/spoke-vpc/vpc.tf
+++ b/aws/spoke-vpc/vpc.tf
@@ -14,6 +14,112 @@ variable "shared_vpc_remote_state_path" {
   default = "master/prd/shared-vpc"
 }
 
+variable "kms_arn" {
+  type        = "string"
+  default     = "alias/parameter_store_key"
+  description = "The ARN of a KMS key used to encrypt and decrypt SecretString values"
+}
+
+variable "map_public_ip_on_launch" {
+  description = "Should be false if you do not want to auto-assign public IP on launch"
+  default     = false
+}
+
+variable "enable_nat_gateway" {
+  description = "Should be true if you want to provision NAT Gateways for each of your private networks"
+  default     = false
+}
+
+variable "single_nat_gateway" {
+  description = "Should be true if you want to provision a single shared NAT Gateway across all of your private networks"
+  default     = false
+}
+
+variable "one_nat_gateway_per_az" {
+  description = "Should be true if you want only one NAT Gateway per availability zone. Requires `var.azs` to be set, and the number of `public_subnets` created to be greater than or equal to the number of availability zones specified in `var.azs`."
+  default     = false
+}
+
+variable "enable_dynamodb_endpoint" {
+  description = "Should be true if you want to provision a DynamoDB endpoint to the VPC"
+  default     = true
+}
+
+variable "enable_s3_endpoint" {
+  description = "Should be true if you want to provision an S3 endpoint to the VPC"
+  default     = true
+}
+
+variable "enable_sqs_endpoint" {
+  description = "Should be true if you want to provision an SQS endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ssm_endpoint" {
+  description = "Should be true if you want to provision an SSM endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ssmmessages_endpoint" {
+  description = "Should be true if you want to provision a SSMMESSAGES endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_apigw_endpoint" {
+  description = "Should be true if you want to provision an api gateway endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ec2_endpoint" {
+  description = "Should be true if you want to provision an EC2 endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ec2messages_endpoint" {
+  description = "Should be true if you want to provision an EC2MESSAGES endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecr_api_endpoint" {
+  description = "Should be true if you want to provision an ecr api endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecr_dkr_endpoint" {
+  description = "Should be true if you want to provision an ecr dkr endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_kms_endpoint" {
+  description = "Should be true if you want to provision a KMS endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecs_endpoint" {
+  description = "Should be true if you want to provision a ECS endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecs_agent_endpoint" {
+  description = "Should be true if you want to provision a ECS Agent endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_ecs_telemetry_endpoint" {
+  description = "Should be true if you want to provision a ECS Telemetry endpoint to the VPC"
+  default     = false
+}
+
+variable "enable_dns_hostnames" {
+  description = "Should be true to enable DNS hostnames in the VPC"
+  default     = true
+}
+
+variable "enable_dns_support" {
+  description = "Should be true to enable DNS support in the VPC"
+  default     = true
+}
+
 data "terraform_remote_state" "shared_vpc" {
   backend = "s3"
 
@@ -35,6 +141,82 @@ locals {
 # MODULES / RESOURCES
 # ----------------------------------------------------------------------------------------------------------------------
 
+# Create a default key/pair for public and private instances
+
+locals {
+  module_ssh_key_pair_public_tags = "${merge(local.tags, map(
+    "TerraformModule", "cloudposse/terraform-aws-key-pair",
+    "TerraformModuleVersion", "0.2.5"))}"
+}
+
+module "ssh_key_pair_public" {
+  source    = "git::https://github.com/cloudposse/terraform-aws-key-pair.git?ref=0.2.5"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.environment}-${var.name}-public"
+  tags      = "${local.module_ssh_key_pair_public_tags}"
+
+  ssh_public_key_path   = "${pathexpand("~/.ssh")}/${var.namespace}"
+  generate_ssh_key      = "${var.create}"
+  private_key_extension = ".pem"
+  public_key_extension  = ".pub"
+  chmod_command         = "chmod 600 %v"
+}
+
+locals {
+  module_ssh_key_pair_private_tags = "${merge(local.tags, map(
+    "TerraformModule", "gravicore/terraform-gravicore-modules/aws/shared-vpc/key-pair",
+    "TerraformModuleVersion", "issues/4"))}"
+}
+
+module "ssh_key_pair_private" {
+  source    = "./key-pair"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.environment}-${var.name}-private"
+  tags      = "${local.module_ssh_key_pair_private_tags}"
+
+  ssh_public_key_path   = "${pathexpand("~/.ssh")}/${var.namespace}"
+  generate_ssh_key      = "${var.create}"
+  private_key_extension = ".pem"
+  public_key_extension  = ".pub"
+  chmod_command         = "chmod 600 %v"
+}
+
+locals {
+  ssh_secret_ssm_write = [
+    {
+      name        = "/${local.stage_prefix}/${var.name}-private-pem"
+      value       = "${module.ssh_key_pair_private.private_key}"
+      type        = "SecureString"
+      overwrite   = "true"
+      description = "${join(" ", list(var.desc_prefix, "Private SSH Key for EC2 Instances in Private VPC Subnet"))}"
+    },
+    {
+      name        = "/${local.stage_prefix}/${var.name}-private-pub"
+      value       = "${module.ssh_key_pair_private.public_key}"
+      type        = "SecureString"
+      overwrite   = "true"
+      description = "${join(" ", list(var.desc_prefix, "Public SSH Key for EC2 Instances in Private VPC Subnet"))}"
+    },
+  ]
+
+  # `ssh_secret_ssm_write_count` needs to be updated if `ssh_secret_ssm_write` changes
+  ssh_secret_ssm_write_count = 2
+}
+
+resource "aws_ssm_parameter" "default" {
+  count           = "${var.create == "true" ? local.ssh_secret_ssm_write_count : 0}"
+  name            = "${lookup(local.ssh_secret_ssm_write[count.index], "name")}"
+  description     = "${lookup(local.ssh_secret_ssm_write[count.index], "description", lookup(local.ssh_secret_ssm_write[count.index], "name"))}"
+  type            = "${lookup(local.ssh_secret_ssm_write[count.index], "type", "SecureString")}"
+  key_id          = "${lookup(local.ssh_secret_ssm_write[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""}"
+  value           = "${lookup(local.ssh_secret_ssm_write[count.index], "value")}"
+  overwrite       = "${lookup(local.ssh_secret_ssm_write[count.index], "overwrite", "false")}"
+  allowed_pattern = "${lookup(local.ssh_secret_ssm_write[count.index], "allowed_pattern", "")}"
+  tags            = "${local.tags}"
+}
+
 locals {
   module_vpc_tags = "${merge(local.tags, map(
     "TerraformModule", "terraform-aws-modules/terraform-aws-vpc",
@@ -42,21 +224,36 @@ locals {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.46.0"
+  source     = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.66.0"
   create_vpc = "${var.create == "true" ?  1 : 0}"
   name       = "${local.module_prefix}"
   tags       = "${local.module_vpc_tags}"
 
-  azs                      = ["${var.aws_region}a", "${var.aws_region}b"]
-  cidr                     = "${var.cidr_network}.0.0/16"
-  private_subnets          = ["${var.cidr_network}.0.0/19", "${var.cidr_network}.32.0/19"]
-  public_subnets           = ["${var.cidr_network}.128.0/20", "${var.cidr_network}.144.0/20"]
-  map_public_ip_on_launch  = false
-  enable_nat_gateway       = false
-  enable_dynamodb_endpoint = true
-  enable_s3_endpoint       = true
-  enable_dns_support       = true
-  enable_dns_hostnames     = true
+  azs                           = ["${var.aws_region}a", "${var.aws_region}b"]
+  cidr                          = "${var.cidr_network}.0.0/16"
+  private_subnets               = ["${var.cidr_network}.0.0/19", "${var.cidr_network}.32.0/19"]
+  public_subnets                = ["${var.cidr_network}.128.0/20", "${var.cidr_network}.144.0/20"]
+  map_public_ip_on_launch       = "${var.map_public_ip_on_launch}"
+  enable_nat_gateway            = "${var.enable_nat_gateway}"
+  single_nat_gateway            = "${var.single_nat_gateway}"
+  one_nat_gateway_per_az        = "${var.one_nat_gateway_per_az}"
+  enable_dynamodb_endpoint      = "${var.enable_dynamodb_endpoint}"
+  enable_s3_endpoint            = "${var.enable_s3_endpoint}"
+  enable_dns_support            = "${var.enable_dns_support}"
+  enable_dns_hostnames          = "${var.enable_dns_hostnames}"
+  enable_sqs_endpoint           = "${var.enable_sqs_endpoint}"
+  enable_ssm_endpoint           = "${var.enable_ssm_endpoint}"
+  enable_ssmmessages_endpoint   = "${var.enable_ssmmessages_endpoint}"
+  enable_apigw_endpoint         = "${var.enable_apigw_endpoint}"
+  enable_ec2_endpoint           = "${var.enable_ec2_endpoint}"
+  enable_ecr_api_endpoint       = "${var.enable_ecr_api_endpoint}"
+  enable_ecr_dkr_endpoint       = "${var.enable_ecr_dkr_endpoint}"
+  enable_kms_endpoint           = "${var.enable_kms_endpoint}"
+  enable_ecs_endpoint           = "${var.enable_ecs_endpoint}"
+  enable_ecs_agent_endpoint     = "${var.enable_ecs_agent_endpoint}"
+  enable_ecs_telemetry_endpoint = "${var.enable_ecs_telemetry_endpoint}"
+  enable_dns_support            = "${var.enable_dns_support}"
+  enable_dns_hostnames          = "${var.enable_dns_hostnames}"
 
   enable_dhcp_options               = "${var.associate_ds == "true" ? true : false}"
   dhcp_options_domain_name          = "${data.terraform_remote_state.shared_vpc.ds_domain_name}"

--- a/aws/spoke-vpc/vpc.tf
+++ b/aws/spoke-vpc/vpc.tf
@@ -220,7 +220,7 @@ resource "aws_ssm_parameter" "default" {
 locals {
   module_vpc_tags = "${merge(local.tags, map(
     "TerraformModule", "terraform-aws-modules/terraform-aws-vpc",
-    "TerraformModuleVersion", "v1.46.0"))}"
+    "TerraformModuleVersion", "v1.66.0"))}"
 }
 
 module "vpc" {


### PR DESCRIPTION
Updated VPC module to most current terraform 11 compatible release.
Added variables for all available resources and endpoints.
Moved SSH key generation out of test instance and into main module.