### PR TITLE
GRVDEV-87 Create AWS Parameters Module

### DIFF
--- a/aws/parameters/iam.tf
+++ b/aws/parameters/iam.tf
@@ -1,0 +1,99 @@
+# # ----------------------------------------------------------------------------------------------------------------------
+# # VARIABLES / LOCALS / REMOTE STATE
+# # ----------------------------------------------------------------------------------------------------------------------
+
+# variable allow_gravicore_access {
+#   description = "Flag to establish SAML connectivity for Gravicore managed services"
+#   default     = false
+# }
+
+# variable "role_max_session_duration" {
+#   type        = number
+#   default     = 43200
+#   description = "The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours."
+# }
+
+# variable "trusted_account_ids" {
+#   type        = list(string)
+#   default     = []
+#   description = ""
+# }
+
+# locals {
+#   trusted_account_ids = coalescelist(var.trusted_account_ids, [local.account_id])
+# }
+
+# # ----------------------------------------------------------------------------------------------------------------------
+# # MODULES / RESOURCES
+# # ----------------------------------------------------------------------------------------------------------------------
+
+# data "template_file" "assume_role_policy" {
+#   count = var.create && length(var.write_parameters) > 0 ? 1 : 0
+
+#   vars     = {}
+#   template = <<TEMPLATE
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Principal": {
+#         "AWS": "arn:aws:iam::${local.account_id}:root"
+#       },
+#       "Action": "sts:AssumeRole"
+#     }
+#   ]
+# }
+# TEMPLATE
+# }
+
+# data "aws_iam_policy_document" "trusted_entities" {
+#   count = var.create && length(var.write_parameters) > 0 ? 1 : 0
+
+#   statement {
+#     actions = ["sts:AssumeRole"]
+#     principals {
+#       type        = "AWS"
+#       identifiers = local.trusted_account_ids
+#     }
+#   }
+#   #   statement {
+#   #     actions = ["sts:AssumeRoleWithSAML"]
+#   #     principals {
+#   #       type        = "Federated"
+#   #       identifiers = local.federated_trusted_entities
+#   #     }
+#   #   }
+# }
+
+# data "aws_iam_policy_document" "parameters" {
+#   count = var.create && length(var.write_parameters) > 0 ? 1 : 0
+
+#   statement {
+#     actions   = ["ssm:DescribeParameters"]
+#     resources = ["*"]
+#   }
+#   statement {
+#     actions = ["ssm:GetParameters"]
+#     resources = [
+#       "arn:aws:ssm:${var.aws_region}:${local.account_id}:parameter/${local.stage_prefix}/*",
+#     ]
+#   }
+# }
+
+# resource "aws_iam_role" "parameters" {
+#   count = var.create && length(var.write_parameters) > 0 ? 1 : 0
+#   name  = join(var.delimiter, [var.namespace, "parameters"])
+#   tags  = local.tags
+
+#   assume_role_policy   = data.template_file.assume_role_policy[0].rendered
+#   max_session_duration = var.role_max_session_duration
+# }
+
+# resource "aws_iam_role_policy" "parameters" {
+#   count = var.create && length(var.write_parameters) > 0 ? 1 : 0
+#   name  = replace("${var.namespace}-parameter-access", "-", var.delimiter)
+
+#   role   = aws_iam_role.parameters[0].name
+#   policy = data.aws_iam_policy_document.parameters[0].json
+# }

--- a/aws/parameters/module.tf
+++ b/aws/parameters/module.tf
@@ -1,0 +1,157 @@
+terraform {
+  required_version = "~> 0.12"
+
+  required_providers {
+    aws = "~> 2.26"
+  }
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Module Standard Variables
+# ----------------------------------------------------------------------------------------------------------------------
+
+variable "name" {
+  type        = string
+  default     = "parameters"
+  description = "The name of the module"
+}
+
+variable terraform_module {
+  type        = string
+  default     = "gravicore/terraform-gravicore-modules/aws/aviatrix/parameters"
+  description = "The owner and name of the Terraform module"
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "The AWS region to deploy module into"
+}
+
+variable "create" {
+  type        = bool
+  default     = true
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Platform Standard Variables
+# ----------------------------------------------------------------------------------------------------------------------
+
+# Recommended
+
+variable "namespace" {
+  type        = string
+  default     = ""
+  description = "Namespace, which could be your organization abbreviation, client name, etc. (e.g. Gravicore 'grv', HashiCorp 'hc')"
+}
+
+variable "environment" {
+  type        = string
+  default     = ""
+  description = "The isolated environment the module is associated with (e.g. Shared Services `shared`, Application `app`)"
+}
+
+variable "stage" {
+  type        = string
+  default     = ""
+  description = "The development stage (i.e. `dev`, `stg`, `prd`)"
+}
+
+variable "repository" {
+  type        = string
+  default     = ""
+  description = "The repository where the code referencing the module is stored"
+}
+
+variable "account_id" {
+  type        = string
+  default     = ""
+  description = "The AWS Account ID that contains the calling entity"
+}
+
+variable "master_account_id" {
+  type        = string
+  default     = ""
+  description = "The Master AWS Account ID that owns the associate AWS account"
+}
+
+# Optional
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional map of tags (e.g. business_unit, cost_center)"
+}
+
+variable "desc_prefix" {
+  type        = string
+  default     = "Gravicore:"
+  description = "The prefix to add to any descriptions attached to resources"
+}
+
+variable "environment_prefix" {
+  type        = string
+  default     = ""
+  description = "Concatenation of `namespace` and `environment`"
+}
+
+variable "stage_prefix" {
+  type        = string
+  default     = ""
+  description = "Concatenation of `namespace`, `environment` and `stage`"
+}
+
+variable "module_prefix" {
+  type        = string
+  default     = ""
+  description = "Concatenation of `namespace`, `environment`, `stage` and `name`"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `environment`, `stage`, `name`"
+}
+
+# Derived
+
+data "aws_caller_identity" "current" {
+  count = var.account_id == "" ? 1 : 0
+}
+
+locals {
+  account_id = coalesce(var.account_id, data.aws_caller_identity.current[0].account_id)
+
+  environment_prefix = coalesce(var.environment_prefix, join(var.delimiter, compact([var.namespace, var.environment])))
+  stage_prefix       = coalesce(var.stage_prefix, join(var.delimiter, compact([local.environment_prefix, var.stage])))
+  module_prefix      = coalesce(var.module_prefix, join(var.delimiter, compact([local.stage_prefix, var.name])))
+
+  business_tags = {
+    namespace          = var.namespace
+    environment        = var.environment
+    environment_prefix = local.environment_prefix
+  }
+  technical_tags = {
+    stage             = var.stage
+    module            = var.name
+    repository        = var.repository
+    master_account_id = var.master_account_id
+    account_id        = local.account_id
+    aws_region        = var.aws_region
+  }
+  automation_tags = {
+    terraform_module = var.terraform_module
+    stage_prefix     = local.stage_prefix
+    module_prefix    = local.module_prefix
+  }
+  security_tags = {}
+
+  tags = merge(
+    local.business_tags,
+    local.technical_tags,
+    local.automation_tags,
+    local.security_tags,
+    var.tags
+  )
+}

--- a/aws/parameters/module.tf
+++ b/aws/parameters/module.tf
@@ -42,7 +42,7 @@ variable "create" {
 
 variable "namespace" {
   type        = string
-  default     = ""
+  default     = "namespace"
   description = "Namespace, which could be your organization abbreviation, client name, etc. (e.g. Gravicore 'grv', HashiCorp 'hc')"
 }
 

--- a/aws/parameters/read.tf
+++ b/aws/parameters/read.tf
@@ -1,0 +1,65 @@
+# ----------------------------------------------------------------------------------------------------------------------
+# VARIABLES / LOCALS / REMOTE STATE
+# ----------------------------------------------------------------------------------------------------------------------
+
+variable "parameters" {
+  description = "A list of SSM Parameters to fetch"
+  type        = list
+  default     = []
+}
+provider "aws" {}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# MODULES / RESOURCES
+# ----------------------------------------------------------------------------------------------------------------------
+
+data "aws_ssm_parameter" "params" {
+  for_each = var.create ? toset(var.parameters) : []
+  name     = split(":::", each.value)[0]
+}
+
+locals {
+  string_parameters = { for k, v in data.aws_ssm_parameter.params : k => v if v.type == "String" }
+  secret_parameters = { for k, v in data.aws_ssm_parameter.params : k => v if v.type == "SecureString" }
+  list_parameters   = { for k, v in data.aws_ssm_parameter.params : k => merge(v, { value = split(",", v.value) }) if v.type == "StringList" }
+}
+
+# resource "aws_ssm_parameter" "default" {
+#   count           = "${var.enabled == "true" ? length(var.parameter_write) : 0}"
+#   name            = "${lookup(var.parameter_write[count.index], "name")}"
+#   description     = "${lookup(var.parameter_write[count.index], "description", lookup(var.parameter_write[count.index], "name"))}"
+#   type            = "${lookup(var.parameter_write[count.index], "type", "SecureString")}"
+#   key_id          = "${lookup(var.parameter_write[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""}"
+#   value           = "${lookup(var.parameter_write[count.index], "value")}"
+#   overwrite       = "${lookup(var.parameter_write[count.index], "overwrite", "false")}"
+#   allowed_pattern = "${lookup(var.parameter_write[count.index], "allowed_pattern", "")}"
+#   tags            = "${var.tags}"
+# }
+
+# ----------------------------------------------------------------------------------------------------------------------
+# OUTPUTS
+# ----------------------------------------------------------------------------------------------------------------------
+
+output "parameters" {
+  description = ""
+  value = merge(
+    local.string_parameters,
+    local.list_parameters,
+    local.secret_parameters,
+  )
+}
+
+output "string_parameters" {
+  description = "Map of the requested String SSM Parameters"
+  value       = local.string_parameters
+}
+
+output "secret_parameters" {
+  description = "Map of the requested SecretString SSM Parameters"
+  value       = local.secret_parameters
+}
+
+output "list_parameters" {
+  description = "Map of the requested List SSM Parameters"
+  value       = local.list_parameters
+}

--- a/aws/parameters/write.tf
+++ b/aws/parameters/write.tf
@@ -1,0 +1,59 @@
+# ----------------------------------------------------------------------------------------------------------------------
+# VARIABLES / LOCALS / REMOTE STATE
+# ----------------------------------------------------------------------------------------------------------------------
+
+variable "write_parameters" {
+  description = <<DESC
+Map of parameters to write to the SSM Parameter store. Example:
+    { "/grv-shared-dev/rds-postgres-password" = {   // Required - The name of the parameter. If the name contains a path (e.g. any forward slashes (/)), it must be fully qualified with a leading forward slash (/).
+        type = "SecureString" // Required - Valid types are String, StringList and SecureString
+        value = "password1" // Required - The value of the parameter
+        description = "Production database master password" // Optional - The description of the parameter
+        overwrite = false // Optional - Force Overwrite of value if true
+        allowed_pattern = "" // Optional - A regular expression used to validate the parameter value
+    } }
+DESC
+  type        = map
+  default     = {}
+}
+
+variable "kms_arn" {
+  type        = string
+  default     = ""
+  description = "The ARN of a KMS key used to encrypt and decrypt SecretString values"
+}
+
+data "aws_kms_key" "kms" {
+  for_each = var.create && var.kms_arn == "" ? toset(["0"]) : []
+  key_id   = "alias/parameter_store_key"
+}
+
+locals {
+  kms_arn = coalesce(var.kms_arn, data.aws_kms_key.kms["0"].key_id, "")
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# MODULES / RESOURCES
+# ----------------------------------------------------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "write_parameters" {
+  for_each    = var.create ? var.write_parameters : {}
+  name        = each.key
+  description = format("%s %s", var.desc_prefix, lookup(each.value, "description", each.key))
+  tags        = var.tags
+
+  type            = "${lookup(each.value, "type", "String")}"
+  key_id          = lookup(each.value, "type", "SecureString") == "SecureString" ? local.kms_arn : ""
+  value           = each.value.value
+  overwrite       = "${lookup(each.value, "overwrite", true)}"
+  allowed_pattern = "${lookup(each.value, "allowed_pattern", "")}"
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# OUTPUTS
+# ----------------------------------------------------------------------------------------------------------------------
+
+output "write_parameters" {
+  value       = aws_ssm_parameter.write_parameters
+  description = ""
+}


### PR DESCRIPTION
Create an AWS Parameters module that supports writing and reading variables from Parameter store from multiple accounts, so that DevOp engineers can pull outputs from multiple deployment environments.
* Support for reading parameters from an account
* Support for writing parameters to an account
* Supports `String`, `StringList` and `SecureString` types