### PR TITLE
GDEV-195 Remove Region Attribute from S3 Bucket Resources Deprecated in AWS Provider v3.16.0

### DIFF
--- a/aws/arctic-wolf/arctic_wolf.tf
+++ b/aws/arctic-wolf/arctic_wolf.tf
@@ -182,7 +182,6 @@ resource "aws_s3_bucket" "default" {
   bucket = "${local.module_prefix}-cloudtrail-events"
   tags   = local.tags
 
-  region = var.aws_region
   acl    = "private"
 
   dynamic "logging" {

--- a/aws/arctic-wolf/arctic_wolf.tf
+++ b/aws/arctic-wolf/arctic_wolf.tf
@@ -182,7 +182,7 @@ resource "aws_s3_bucket" "default" {
   bucket = "${local.module_prefix}-cloudtrail-events"
   tags   = local.tags
 
-  acl    = "private"
+  acl = "private"
 
   dynamic "logging" {
     for_each = var.s3_bucket_access_logging ? [1] : []

--- a/aws/billing/billing.tf
+++ b/aws/billing/billing.tf
@@ -8,7 +8,6 @@ resource "aws_s3_bucket" "billing" {
   bucket = local.module_prefix
   tags   = var.tags
 
-  region = var.aws_region
   acl    = "private"
 
   versioning {

--- a/aws/billing/billing.tf
+++ b/aws/billing/billing.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "billing" {
   bucket = local.module_prefix
   tags   = var.tags
 
-  acl    = "private"
+  acl = "private"
 
   versioning {
     enabled = var.s3_bucket_versioning

--- a/aws/cicd/cicd.tf
+++ b/aws/cicd/cicd.tf
@@ -92,7 +92,6 @@ resource "aws_iam_access_key" "elevated" {
 resource "aws_s3_bucket" "default" {
   count  = var.create && var.deploy_artifacts_bucket ? 1 : 0
   bucket = join(var.delimiter, [local.module_prefix, "artifacts"])
-  region = var.aws_region
   acl    = "private"
 
   versioning {

--- a/aws/cloudtrail/cloudtrail.tf
+++ b/aws/cloudtrail/cloudtrail.tf
@@ -100,7 +100,6 @@ variable "vpc_flow_log_group_name" {
 resource "aws_s3_bucket" "default" {
   count  = var.create ? 1 : 0
   bucket = join("-", [local.module_prefix, "events"])
-  region = var.aws_region
   acl    = "private"
 
   dynamic "logging" {

--- a/aws/rds/modules/db-option-group/db-option-group.tf
+++ b/aws/rds/modules/db-option-group/db-option-group.tf
@@ -86,7 +86,6 @@ variable "kms_key_id" {
 resource "aws_s3_bucket" "rds_backup_restore" {
   count  = var.create ? 1 : 0
   bucket = "${var.module_prefix}-rds"
-  region = var.aws_region
   acl    = "private"
 
   versioning {

--- a/aws/s3-cdn/s3-cdn.tf
+++ b/aws/s3-cdn/s3-cdn.tf
@@ -426,16 +426,12 @@ resource "aws_s3_bucket_policy" "default" {
   policy = data.template_file.default.rendered
 }
 
-data "aws_region" "current" {
-}
-
 resource "aws_s3_bucket" "origin" {
   count         = signum(length(var.origin_bucket)) == 1 ? 0 : 1
   bucket        = local.module_prefix
   acl           = "private"
   tags          = local.tags
   force_destroy = var.origin_force_destroy
-  region        = data.aws_region.current.name
 
   cors_rule {
     allowed_headers = var.cors_allowed_headers

--- a/aws/s3/s3.tf
+++ b/aws/s3/s3.tf
@@ -95,7 +95,6 @@ variable "ssm_key_id" {
 resource "aws_s3_bucket" "default" {
   count  = var.create ? 1 : 0
   bucket = local.module_prefix
-  region = var.aws_region
   acl    = var.s3_bucket_acl
 
   versioning {


### PR DESCRIPTION
Removed region attribute from aws s3 bucket resources due to depreciation of attribute in AWS provider v3.16.0 causing deployment error.