### PR TITLE
GDEV-211 Update Camunda ECS Container Definitions Attributes to Resolve Forced Recreation on Deployment

### DIFF
--- a/aws/camunda/module/camunda.tf
+++ b/aws/camunda/module/camunda.tf
@@ -477,7 +477,7 @@ module "alb" {
 }
 
 module "datadog" {
-  source                         = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/datadog/ecs?ref=0.31.0"
+  source                         = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/datadog/ecs?ref=0.35.3"
   container_datadog_api_key      = var.datadog_api_key
   container_datadog_service_name = var.name
   name                           = var.name

--- a/aws/datadog/ecs/datadog.tf
+++ b/aws/datadog/ecs/datadog.tf
@@ -45,7 +45,13 @@ locals {
     image             = var.container_datadog_logging_image,
     name              = "${local.module_prefix}-logging",
     essential         = true,
+    cpu               = 0
+    mountPoints       = []
+    volumesFrom       = []
     memoryReservation = 64
+    portMappings      = []
+    environment       = []
+    user              = "0"
     firelensConfiguration = {
       type = "fluentbit",
       options = {
@@ -59,6 +65,8 @@ locals {
     name              = "${local.module_prefix}-metrics",
     essential         = true,
     cpu               = var.container_datadog_metrics_cpu,
+    mountPoints       = []
+    volumesFrom       = []
     memoryReservation = 256,
     portMappings = [{
       hostPort      = 8126,


### PR DESCRIPTION
Pull request created in: https://gravicore.atlassian.net/browse/GDEV-211 by the Git Integration for Jira app.