### PR TITLE
GDEV-369: adding domain name and zone id to the appsync merged api outputs

### DIFF
--- a/aws/appsync-merged-api/bin/destroy.py
+++ b/aws/appsync-merged-api/bin/destroy.py
@@ -6,6 +6,7 @@ MAX_RESULTS = 5
 appsync_api_name = os.getenv("APPSYNC_API_NAME")
 aws_region = os.getenv("AWS_REGION")
 appsync_client = boto3.client("appsync", region_name=aws_region)
+disabled = os.getenv("DISABLED")
 
 
 def get_appsync_api_id_by_name(appsync_api_name):
@@ -29,8 +30,11 @@ def get_appsync_api_id_by_name(appsync_api_name):
 
 
 def main():
-    api_id = get_appsync_api_id_by_name(appsync_api_name)
+    if disabled == "true":
+        print("[terraform] destroy is disabled")
+        return
 
+    api_id = get_appsync_api_id_by_name(appsync_api_name)
     if api_id:
         try:
             appsync_client.delete_graphql_api(apiId=api_id)


### PR DESCRIPTION
- adding zone id and domain name so we can create route 53 records
- disabling merged api destruction by default, it's too unstable and can destroy resources we don't want to... we need a proper terraform provider to manage these resources
- we will be sending the full domain name to be used instead of building it here, as it's easier to fail like this