### PR TITLE
GDEV-373: adding lambda additional authentication for AppSync

### DIFF
--- a/aws/appsync-merge/appsync.tf
+++ b/aws/appsync-merge/appsync.tf
@@ -3,25 +3,22 @@
 # VARIABLES / LOCALS / REMOTE STATE
 # ----------------------------------------------------------------------------------------------------------------------
 variable "graphql" {
+  description = "required. GraphQL schema and resolvers configuration"
   type = object({
     schema = string
     target = object({
-      lambda = string
+      lambda = optional(string, "")
       merge  = string
-    })
-    authentication = object({
-      type      = optional(string, "AMAZON_COGNITO_USER_POOLS")
-      user_pool = string
     })
     resolvers = optional(list(object({
       field = string
       type  = string
     })), [])
   })
-  description = "required. The GraphQL schema and resolvers configuration"
 }
 
 variable "transform" {
+  description = "optional. Request and response transformation configuration"
   type = object({
     request = optional(object({
       type = optional(string, "default")
@@ -32,23 +29,69 @@ variable "transform" {
       body = optional(string, "")
     }), {})
   })
-  default     = {}
-  description = "optional. The request and response transformation configuration"
+  default = {}
+}
+
+variable "authentication" {
+  description = "required. Authentication configuration for the AppSync Merged API"
+  type = list(object({
+    priority = string # principal or secondary
+    cognito = optional(object({
+      user_pool = string
+      region    = optional(string, "")
+      regex     = optional(string, "")
+    }), null)
+    lambda = optional(object({
+      arn   = string
+      ttl   = optional(number, 0)
+      regex = optional(string, "")
+    }), null)
+  }))
+  validation {
+    condition = alltrue([
+      for auth in var.authentication : (
+        (auth.cognito != null && auth.lambda == null) ||
+        (auth.cognito == null && auth.lambda != null)
+      )
+      ]) && alltrue([
+      for auth in var.authentication : (
+        auth.priority == "principal" || auth.priority == "secondary"
+      )
+    ])
+    error_message = "Each authentication object must have either 'cognito' or 'lambda' defined, but not both, and 'priority' must be either 'principal' or 'secondary'."
+  }
 }
 
 # ----------------------------------------------------------------------------------------------------------------------
 # MODULES / RESOURCES
 # ----------------------------------------------------------------------------------------------------------------------
 locals {
-  req          = var.transform.request
-  res          = var.transform.response
+  req = var.transform.request
+  res = var.transform.response
+
   req_template = local.req.body != "" ? local.req.body : file("${path.module}/transform/req/${local.req.type}.vtl")
   res_template = local.res.body != "" ? local.res.body : file("${path.module}/transform/res/${local.res.type}.vtl")
+
+  authentication_types = {
+    cognito = "AMAZON_COGNITO_USER_POOLS"
+    lambda  = "AWS_LAMBDA"
+  }
+
+  authentication = [for i, a in var.authentication : merge(
+    coalesce(a.cognito, a.lambda),
+    {
+      authentication_type = local.authentication_types[[for k in keys(a) : k if a[k] != null][0]]
+      is_cognito          = a.cognito != null
+      is_lambda           = a.lambda != null
+      priority            = a.priority
+  })]
+
+  principal = [for a in local.authentication : a if a.priority == "principal"][0]
+  secondary = [for a in local.authentication : a if a.priority == "secondary"]
 }
 
-
 resource "aws_appsync_datasource" "this" {
-  count            = var.create ? 1 : 0
+  count            = var.create && var.graphql.target.lambda != "" ? 1 : 0
   api_id           = concat(aws_appsync_graphql_api.this.*.id, [""])[0]
   name             = lower(join("", regexall("[a-zA-Z0-9]+", local.module_prefix)))
   service_role_arn = concat(aws_iam_role.this.*.arn, [""])[0]
@@ -61,15 +104,52 @@ resource "aws_appsync_datasource" "this" {
 
 resource "aws_appsync_graphql_api" "this" {
   count               = var.create ? 1 : 0
-  authentication_type = var.graphql.authentication.type
+  authentication_type = local.principal.authentication_type
   name                = local.module_prefix
   schema              = var.graphql.schema
   tags                = local.tags
 
-  user_pool_config {
-    aws_region     = var.aws_region
-    default_action = "ALLOW"
-    user_pool_id   = var.graphql.authentication.user_pool
+  dynamic "user_pool_config" {
+    for_each = local.principal.is_cognito ? [1] : []
+    content {
+      app_id_client_regex = local.principal.regex
+      aws_region          = coalesce(local.principal.region, var.aws_region)
+      default_action      = "ALLOW"
+      user_pool_id        = local.principal.user_pool
+    }
+  }
+
+  dynamic "lambda_authorizer_config" {
+    for_each = local.principal.is_lambda ? [1] : []
+    content {
+      authorizer_result_ttl_in_seconds = local.principal.ttl
+      authorizer_uri                   = local.principal.arn
+      identity_validation_expression   = local.principal.regex
+    }
+  }
+
+  dynamic "additional_authentication_provider" {
+    for_each = local.secondary
+    content {
+      authentication_type = additional_authentication_provider.value.authentication_type
+      dynamic "user_pool_config" {
+        for_each = additional_authentication_provider.value.is_cognito ? [1] : []
+        content {
+          app_id_client_regex = additional_authentication_provider.value.regex
+          aws_region          = coalesce(additional_authentication_provider.value.region, var.aws_region)
+          user_pool_id        = additional_authentication_provider.value.user_pool
+        }
+      }
+
+      dynamic "lambda_authorizer_config" {
+        for_each = additional_authentication_provider.value.is_lambda ? [1] : []
+        content {
+          authorizer_result_ttl_in_seconds = additional_authentication_provider.value.ttl
+          authorizer_uri                   = additional_authentication_provider.value.arn
+          identity_validation_expression   = additional_authentication_provider.value.regex
+        }
+      }
+    }
   }
 }
 
@@ -112,4 +192,9 @@ resource "gravicore_aws_appsync_start_schema_merge" "this" {
 output "appsync_api_id" {
   description = "The ID of the AppSync GraphQL API"
   value       = concat(aws_appsync_graphql_api.this.*.id, [""])[0]
+}
+
+output "appsync_api_arn" {
+  description = "The ID of the AppSync GraphQL API"
+  value       = concat(aws_appsync_graphql_api.this.*.arn, [""])[0]
 }

--- a/aws/appsync-merge/iam.tf
+++ b/aws/appsync-merge/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "trust" {
-  count = var.create ? 1 : 0
+  count = var.create && var.graphql.target.lambda != "" ? 1 : 0
   name  = "${local.module_prefix}-trust"
 
   assume_role_policy = jsonencode({
@@ -17,7 +17,7 @@ resource "aws_iam_role" "trust" {
 }
 
 resource "aws_iam_policy" "trust" {
-  count = var.create ? 1 : 0
+  count = var.create && var.graphql.target.lambda != "" ? 1 : 0
   name  = "${local.module_prefix}-trust"
   policy = jsonencode({
     Version = "2012-10-17",
@@ -36,7 +36,7 @@ resource "aws_iam_policy" "trust" {
 }
 
 resource "aws_iam_role_policy_attachment" "trust" {
-  count      = var.create ? 1 : 0
+  count      = var.create && var.graphql.target.lambda != "" ? 1 : 0
   role       = concat(aws_iam_role.trust.*.name, [""])[0]
   policy_arn = concat(aws_iam_policy.trust.*.arn, [""])[0]
 }
@@ -59,7 +59,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.graphql.target.lambda != "" ? 1 : 0
   name  = "${local.module_prefix}-appsync"
   role  = concat(aws_iam_role.this.*.id, [""])[0]
   policy = jsonencode({

--- a/aws/appsync-merged-api/appsync.tf
+++ b/aws/appsync-merged-api/appsync.tf
@@ -1,46 +1,81 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # VARIABLES / LOCALS / REMOTE STATE
 # ----------------------------------------------------------------------------------------------------------------------
-
-variable "cognito_user_pool_id" {
-  description = "The Cognito User Pool ID"
-  type        = string
-  default     = ""
+variable "domain" {
+  description = "required. Domain configuration for the AppSync Merged API"
+  type = object({
+    zone = string
+    name = string
+    cert = string
+  })
 }
 
-variable "domain_name" {
-  description = "The domain name to associate with the AppAsync API."
-  type        = string
-}
-
-variable "subdomain_name" {
-  description = "The subdomain name to associate with the AppAsync API."
-  type        = string
-}
-
-variable "certificate_arn" {
-  type        = string
-  description = "The certificate to associate with the Custom Domain."
+variable "authentication" {
+  description = "required. Authentication configuration for the AppSync Merged API"
+  type = list(object({
+    priority = string # principal or secondary
+    cognito = optional(object({
+      user_pool = string
+      region    = optional(string, "")
+      regex     = optional(string, "")
+    }), null)
+    lambda = optional(object({
+      arn   = string
+      ttl   = optional(number, 0)
+      regex = optional(string, "")
+    }), null)
+  }))
+  validation {
+    condition = alltrue([
+      for auth in var.authentication : (
+        (auth.cognito != null && auth.lambda == null) ||
+        (auth.cognito == null && auth.lambda != null)
+      )
+      ]) && alltrue([
+      for auth in var.authentication : (
+        auth.priority == "principal" || auth.priority == "secondary"
+      )
+    ])
+    error_message = "Each authentication object must have either 'cognito' or 'lambda' defined, but not both, and 'priority' must be either 'principal' or 'secondary'."
+  }
 }
 
 # ----------------------------------------------------------------------------------------------------------------------
 # MODULES / RESOURCES
 # ----------------------------------------------------------------------------------------------------------------------
+
+locals {
+  authentication_types = {
+    cognito = "AMAZON_COGNITO_USER_POOLS"
+    lambda  = "AWS_LAMBDA"
+  }
+
+  authentication = [for i, a in var.authentication : merge(
+    coalesce(a.cognito, a.lambda),
+    {
+      authentication_type = local.authentication_types[[for k in keys(a) : k if a[k] != null][0]]
+      is_cognito          = a.cognito != null
+      is_lambda           = a.lambda != null
+      priority            = a.priority
+  })]
+
+  principal = [for a in local.authentication : a if a.priority == "principal"][0]
+  secondary = [for a in local.authentication : a if a.priority == "secondary"]
+}
+
 resource "aws_iam_role" "this" {
   count = var.create ? 1 : 0
   name  = local.module_prefix
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "appsync.amazonaws.com"
-        }
-      },
-    ]
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "appsync.amazonaws.com"
+      }
+    }]
   })
 }
 
@@ -79,16 +114,29 @@ data "aws_iam_policy_document" "this" {
 resource "gravicore_aws_appsync_graphql_api" "default" {
   count                         = var.create ? 1 : 0
   api_type                      = "MERGED"
-  authentication_type           = "AMAZON_COGNITO_USER_POOLS"
+  authentication_type           = local.principal.authentication_type
   merged_api_execution_role_arn = concat(aws_iam_role.this.*.arn, [""])[0]
   name                          = local.module_prefix
   tags                          = var.tags
   xray_enabled                  = true
 
-  user_pool_config {
-    aws_region     = var.aws_region
-    default_action = "ALLOW"
-    user_pool_id   = var.cognito_user_pool_id
+  dynamic "user_pool_config" {
+    for_each = local.principal.is_cognito ? [1] : []
+    content {
+      app_id_client_regex = local.principal.regex
+      aws_region          = coalesce(local.principal.region, var.aws_region)
+      default_action      = "ALLOW"
+      user_pool_id        = local.principal.user_pool
+    }
+  }
+
+  dynamic "lambda_authorizer_config" {
+    for_each = local.principal.is_lambda ? [1] : []
+    content {
+      authorizer_result_ttl_seconds  = local.principal.ttl
+      authorizer_uri                 = local.principal.arn
+      identity_validation_expression = local.principal.regex
+    }
   }
 
   enhanced_metrics_config {
@@ -102,13 +150,37 @@ resource "gravicore_aws_appsync_graphql_api" "default" {
     exclude_verbose_content  = true
     field_log_level          = "NONE"
   }
+
+  dynamic "additional_authentication_providers" {
+    for_each = local.secondary
+    content {
+      authentication_type = additional_authentication_providers.value.authentication_type
+      dynamic "user_pool_config" {
+        for_each = additional_authentication_providers.value.is_cognito ? [1] : []
+        content {
+          app_id_client_regex = additional_authentication_providers.value.regex
+          aws_region          = coalesce(additional_authentication_providers.value.region, var.aws_region)
+          user_pool_id        = additional_authentication_providers.value.user_pool
+        }
+      }
+
+      dynamic "lambda_authorizer_config" {
+        for_each = additional_authentication_providers.value.is_lambda ? [1] : []
+        content {
+          authorizer_result_ttl_seconds  = additional_authentication_providers.value.ttl
+          authorizer_uri                 = additional_authentication_providers.value.arn
+          identity_validation_expression = additional_authentication_providers.value.regex
+        }
+      }
+    }
+  }
 }
 
 resource "aws_appsync_domain_name" "default" {
   count           = var.create ? 1 : 0
-  domain_name     = "${var.subdomain_name}.${var.domain_name}"
+  domain_name     = "${var.domain.name}.${var.domain.zone}"
   description     = "create custom domain name for appsync"
-  certificate_arn = var.certificate_arn
+  certificate_arn = var.domain.cert
 }
 
 resource "aws_appsync_domain_name_api_association" "this" {


### PR DESCRIPTION
**appsync-merged-api usage:**
```hcl
module "appsync_merged_api" {
  source = "../appsync-merged-api"

  domain = {
    zone = "example.com"
    name = "graphql"
    cert = "arn:aws:acm..."
  }

  authentication = [{
    priority = "principal"
    cognito = {
      user_pool = "us-east-1_..."
    }
    }, {
    priority = "secondary"
    lambda = {
      arn   = "arn:aws:lambda..."
      regex = "(?i)^bearer\\s+(.+)"
    }
  }]
}
```

**appsync-merge usage:**
```hcl
module "appsync" {
  source = "../appsync-merge"

  graphql = {
    schema = file("schema.graphql")
    target = {
      lambda = "arn:aws:lambda..."
      merge  = "arn:aws:appsync..."
    }
    resolvers = [{
      type  = "Mutation"
      field = "MyMutation"
    }]
  }

  authentication = [{
    priority = "principal"
    cognito = {
      user_pool = "us-east-1_..."
    }
    }, {
    priority = "secondary"
    lambda = {
      arn   = "arn:aws:lambda..."
      regex = "(?i)^bearer\\s+(.+)"
    }
  }]
}
```