### PR TITLE
SEC-3928: fix S3 policy

### DIFF
--- a/aws/alb/access_logs.tf
+++ b/aws/alb/access_logs.tf
@@ -146,7 +146,7 @@ resource "aws_s3_bucket_policy" "default" {
   count  = var.create ? 1 : 0
   bucket = join("", aws_s3_bucket.default.*.id)
 
-  policy = jsondecode({
+  policy = jsonencode({
     Id      = "Policy",
     Version = "2012-10-17",
     Statement = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk one-line Terraform change, but it affects an S3 bucket policy so misconfiguration could impact log delivery if incorrectly applied.
> 
> **Overview**
> Updates `aws/alb/access_logs.tf` to generate the `aws_s3_bucket_policy` document with `jsonencode(...)` instead of `jsondecode(...)`, ensuring Terraform passes a valid JSON string to the S3 bucket policy resource.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b88b32a0104cd0a144427927499f7bccf7ac85a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->