### PR TITLE
GDEV-435 Update Aviatrix Module to Resolve Removal of TGW CIDR

### DIFF
--- a/aws/aviatrix/accounts/module.tf
+++ b/aws/aviatrix/accounts/module.tf
@@ -6,7 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.26"
     }
-    aviatrix = ">= 2.14"
+    aviatrix = {
+      version = "2.21.2"
+      source  = "aviatrixsystems/aviatrix"
+    }
   }
 }
 

--- a/aws/aviatrix/accounts/module.tf
+++ b/aws/aviatrix/accounts/module.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 2.26"
     }
     aviatrix = {
-      version = "2.21.2"
+      version = ">= 2.21.2"
       source  = "aviatrixsystems/aviatrix"
     }
   }

--- a/aws/aviatrix/tgw/module.tf
+++ b/aws/aviatrix/tgw/module.tf
@@ -6,7 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.26"
     }
-    aviatrix = ">= 2.14"
+    aviatrix = {
+      version = ">= 2.21.2"
+      source  = "aviatrixsystems/aviatrix"
+    }
   }
 }
 

--- a/aws/aviatrix/tgw/tgw.tf
+++ b/aws/aviatrix/tgw/tgw.tf
@@ -100,9 +100,9 @@ resource "aviatrix_aws_tgw" "tgw" {
       aviatrix_firewall    = security_domains.key == "Aviatrix_Firewall_Domain" ? true : false
     }
   }
-  
+
   lifecycle {
-    ignore_changes = [ cidrs ]
+    ignore_changes = [cidrs]
   }
 }
 

--- a/aws/aviatrix/tgw/tgw.tf
+++ b/aws/aviatrix/tgw/tgw.tf
@@ -100,6 +100,10 @@ resource "aviatrix_aws_tgw" "tgw" {
       aviatrix_firewall    = security_domains.key == "Aviatrix_Firewall_Domain" ? true : false
     }
   }
+  
+  lifecycle {
+    ignore_changes = [ cidrs ]
+  }
 }
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/aws/aviatrix/tgw/tgw_vpn_connections.tf
+++ b/aws/aviatrix/tgw/tgw_vpn_connections.tf
@@ -72,4 +72,5 @@ resource "aws_ssm_parameter" "tgw_vpn_connections" {
 output "tgw_vpn_connections" {
   value       = aviatrix_aws_tgw_vpn_conn.tgw_vpn_connections
   description = "Map of provisioned Aviatrix AWS TGW VPN Connections"
+  sensitive   = true
 }

--- a/aws/aviatrix/vpn/module.tf
+++ b/aws/aviatrix/vpn/module.tf
@@ -6,7 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.26"
     }
-    aviatrix = ">= 2.14"
+    aviatrix = {
+      version = ">= 2.21.2"
+      source  = "aviatrixsystems/aviatrix"
+    }
   }
 }
 

--- a/aws/aviatrix/vpn/profiles.tf
+++ b/aws/aviatrix/vpn/profiles.tf
@@ -95,21 +95,21 @@ resource "aviatrix_vpn_profile" "profiles" {
 
 # SSM Parameters
 
-module "parameters_vpn_profiles" {
-  source = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.32.0"
-  # source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=GRVDEV-81-Create-Aviatrix-modules"
-  providers   = { aws = aws }
-  create      = var.create && var.create_parameters
-  namespace   = var.namespace
-  environment = var.environment
-  stage       = var.stage
-  tags        = local.tags
+# module "parameters_vpn_profiles" {
+#   source = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.32.0"
+#   # source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=GRVDEV-81-Create-Aviatrix-modules"
+#   providers   = { aws = aws }
+#   create      = var.create && var.create_parameters
+#   namespace   = var.namespace
+#   environment = var.environment
+#   stage       = var.stage
+#   tags        = local.tags
 
-  write_parameters = {
-    "/${local.stage_prefix}/${var.name}-profile-names" = { value = join(",", [for k, v in aviatrix_vpn_profile.profiles : k]), type = "StringList"
-    description = "List of Aviatrix VPN profile names" }
-  }
-}
+#   write_parameters = {
+#     "/${local.stage_prefix}/${var.name}-profile-names" = { value = join(",", [for k, v in aviatrix_vpn_profile.profiles : k]), type = "StringList"
+#     description = "List of Aviatrix VPN profile names" }
+#   }
+# }
 
 # Outputs
 

--- a/aws/aviatrix/vpn/vpn.tf
+++ b/aws/aviatrix/vpn/vpn.tf
@@ -130,34 +130,34 @@ resource "aws_route53_record" "avx_vpn_gw" {
 
 # SSM Parameters
 
-module "parameters_vpn" {
-  source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.32.0"
-  providers   = { aws = "aws" }
-  create      = var.create && var.create_parameters
-  namespace   = var.namespace
-  environment = var.environment
-  stage       = var.stage
-  tags        = local.tags
+# module "parameters_vpn" {
+#   source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.32.0"
+#   providers   = { aws = "aws" }
+#   create      = var.create && var.create_parameters
+#   namespace   = var.namespace
+#   environment = var.environment
+#   stage       = var.stage
+#   tags        = local.tags
 
-  write_parameters = {
-    "/${local.stage_prefix}/${var.name}-public-ip" = { value = aviatrix_gateway.avx_vpn_gw[0].eip,
-    description = "Public IP address of the Gateway created" }
-    "/${local.stage_prefix}/${var.name}-backup-public-ip" = { value = aviatrix_gateway.avx_vpn_gw[0].peering_ha_eip,
-    description = "Private IP address of the Gateway created" }
-    "/${local.stage_prefix}/${var.name}-public-dns-server" = { value = aviatrix_gateway.avx_vpn_gw[0].public_dns_server,
-    description = "DNS server used by the gateway. Default is `8.8.8.8`, can be overridden with the VPC's setting." }
-    "/${local.stage_prefix}/${var.name}-security-group-id" = { value = aviatrix_gateway.avx_vpn_gw[0].security_group_id,
-    description = "Security group used for the gateway" }
-    "/${local.stage_prefix}/${var.name}-instance-id" = { value = aviatrix_gateway.avx_vpn_gw[0].cloud_instance_id
-    description = "Instance ID of the gateway" }
-    "/${local.stage_prefix}/${var.name}-backup-instance-id" = { value = aviatrix_gateway.avx_vpn_gw[0].peering_ha_cloud_instance_id
-    description = "Instance ID of the backup gateway" }
-    "/${local.stage_prefix}/${var.name}-dns-name" = { value = aws_route53_record.avx_vpn_gw[0].name,
-    description = "DNS name of the Aviatrix VPN Gateway" }
-    "/${local.stage_prefix}/${var.name}-dns-fqdn" = { value = aws_route53_record.avx_vpn_gw[0].fqdn
-    description = "FQDN built using the zone domain and name" }
-  }
-}
+#   write_parameters = {
+#     "/${local.stage_prefix}/${var.name}-public-ip" = { value = aviatrix_gateway.avx_vpn_gw[0].eip,
+#     description = "Public IP address of the Gateway created" }
+#     "/${local.stage_prefix}/${var.name}-backup-public-ip" = { value = aviatrix_gateway.avx_vpn_gw[0].peering_ha_eip,
+#     description = "Private IP address of the Gateway created" }
+#     "/${local.stage_prefix}/${var.name}-public-dns-server" = { value = aviatrix_gateway.avx_vpn_gw[0].public_dns_server,
+#     description = "DNS server used by the gateway. Default is `8.8.8.8`, can be overridden with the VPC's setting." }
+#     "/${local.stage_prefix}/${var.name}-security-group-id" = { value = aviatrix_gateway.avx_vpn_gw[0].security_group_id,
+#     description = "Security group used for the gateway" }
+#     "/${local.stage_prefix}/${var.name}-instance-id" = { value = aviatrix_gateway.avx_vpn_gw[0].cloud_instance_id
+#     description = "Instance ID of the gateway" }
+#     "/${local.stage_prefix}/${var.name}-backup-instance-id" = { value = aviatrix_gateway.avx_vpn_gw[0].peering_ha_cloud_instance_id
+#     description = "Instance ID of the backup gateway" }
+#     "/${local.stage_prefix}/${var.name}-dns-name" = { value = aws_route53_record.avx_vpn_gw[0].name,
+#     description = "DNS name of the Aviatrix VPN Gateway" }
+#     "/${local.stage_prefix}/${var.name}-dns-fqdn" = { value = aws_route53_record.avx_vpn_gw[0].fqdn
+#     description = "FQDN built using the zone domain and name" }
+#   }
+# }
 
 # Outputs
 


### PR DESCRIPTION
Pull request created in: https://gravicore.atlassian.net/browse/GDEV-435 by the Git Integration for Jira app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades and pins the `aviatrix` provider and changes TGW resource lifecycle to ignore `cidrs`, which can mask drift and alter apply behavior for existing deployments. Also adjusts outputs/parameter publishing, which may affect downstream consumers and state/output sensitivity.
> 
> **Overview**
> Pins the `aviatrix` Terraform provider to `aviatrixsystems/aviatrix` and bumps the minimum version to `>= 2.21.2` across the `accounts`, `tgw`, and `vpn` modules.
> 
> Updates the `aviatrix_aws_tgw` resource to `ignore_changes = [cidrs]` to prevent plans/applies from reacting to TGW CIDR changes (e.g., CIDR removal).
> 
> Marks the `tgw_vpn_connections` output as `sensitive`, and comments out the SSM parameter-writing modules for VPN gateway and VPN profiles (disabling those SSM outputs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 736e80f2d8e2a8f56735da720746c0ce353262c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->