### PR TITLE
GDEV-435 Update Aviatrix Module to Resolve Removal of TGW CIDR

### DIFF
--- a/aws/aviatrix/accounts/accounts.tf
+++ b/aws/aviatrix/accounts/accounts.tf
@@ -31,7 +31,7 @@ resource "aviatrix_account" "accounts" {
 # SSM Parameters
 
 module "parameters_accounts" {
-  source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.32.0"
+  source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.56.4"
   providers   = { aws = "aws" }
   create      = var.create && var.create_parameters
   namespace   = var.namespace
@@ -54,6 +54,7 @@ module "parameters_accounts" {
 output "aviatrix_accounts" {
   value       = aviatrix_account.accounts
   description = "Map of Aviatrix Accounts and attributes"
+  sensitive   = true
 }
 
 output "aviatrix_accounts_names" {

--- a/aws/aviatrix/controller/controller.tf
+++ b/aws/aviatrix/controller/controller.tf
@@ -226,7 +226,7 @@ resource "random_password" "admin_password" {
 # SSM Parameters
 
 module "parameters_controller" {
-  source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.32.0"
+  source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.56.4"
   providers   = { aws = "aws" }
   create      = var.create && var.create_parameters
   namespace   = var.namespace

--- a/aws/aviatrix/controller/module.tf
+++ b/aws/aviatrix/controller/module.tf
@@ -6,7 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.26"
     }
-    aviatrix = ">= 2.14"
+    aviatrix = {
+      version = ">= 2.21.2"
+      source  = "aviatrixsystems/aviatrix"
+    }
   }
 }
 

--- a/aws/aviatrix/vpn/profiles.tf
+++ b/aws/aviatrix/vpn/profiles.tf
@@ -95,21 +95,21 @@ resource "aviatrix_vpn_profile" "profiles" {
 
 # SSM Parameters
 
-# module "parameters_vpn_profiles" {
-#   source = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.32.0"
-#   # source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=GRVDEV-81-Create-Aviatrix-modules"
-#   providers   = { aws = aws }
-#   create      = var.create && var.create_parameters
-#   namespace   = var.namespace
-#   environment = var.environment
-#   stage       = var.stage
-#   tags        = local.tags
+module "parameters_vpn_profiles" {
+  source = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.56.4"
+  # source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=GRVDEV-81-Create-Aviatrix-modules"
+  providers   = { aws = aws }
+  create      = var.create && var.create_parameters
+  namespace   = var.namespace
+  environment = var.environment
+  stage       = var.stage
+  tags        = local.tags
 
-#   write_parameters = {
-#     "/${local.stage_prefix}/${var.name}-profile-names" = { value = join(",", [for k, v in aviatrix_vpn_profile.profiles : k]), type = "StringList"
-#     description = "List of Aviatrix VPN profile names" }
-#   }
-# }
+  write_parameters = {
+    "/${local.stage_prefix}/${var.name}-profile-names" = { value = join(",", [for k, v in aviatrix_vpn_profile.profiles : k]), type = "StringList"
+    description = "List of Aviatrix VPN profile names" }
+  }
+}
 
 # Outputs
 

--- a/aws/aviatrix/vpn/vpn.tf
+++ b/aws/aviatrix/vpn/vpn.tf
@@ -130,34 +130,34 @@ resource "aws_route53_record" "avx_vpn_gw" {
 
 # SSM Parameters
 
-# module "parameters_vpn" {
-#   source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.32.0"
-#   providers   = { aws = "aws" }
-#   create      = var.create && var.create_parameters
-#   namespace   = var.namespace
-#   environment = var.environment
-#   stage       = var.stage
-#   tags        = local.tags
+module "parameters_vpn" {
+  source      = "git::https://github.com/gravicore/terraform-gravicore-modules.git//aws/parameters?ref=0.56.4"
+  providers   = { aws = "aws" }
+  create      = var.create && var.create_parameters
+  namespace   = var.namespace
+  environment = var.environment
+  stage       = var.stage
+  tags        = local.tags
 
-#   write_parameters = {
-#     "/${local.stage_prefix}/${var.name}-public-ip" = { value = aviatrix_gateway.avx_vpn_gw[0].eip,
-#     description = "Public IP address of the Gateway created" }
-#     "/${local.stage_prefix}/${var.name}-backup-public-ip" = { value = aviatrix_gateway.avx_vpn_gw[0].peering_ha_eip,
-#     description = "Private IP address of the Gateway created" }
-#     "/${local.stage_prefix}/${var.name}-public-dns-server" = { value = aviatrix_gateway.avx_vpn_gw[0].public_dns_server,
-#     description = "DNS server used by the gateway. Default is `8.8.8.8`, can be overridden with the VPC's setting." }
-#     "/${local.stage_prefix}/${var.name}-security-group-id" = { value = aviatrix_gateway.avx_vpn_gw[0].security_group_id,
-#     description = "Security group used for the gateway" }
-#     "/${local.stage_prefix}/${var.name}-instance-id" = { value = aviatrix_gateway.avx_vpn_gw[0].cloud_instance_id
-#     description = "Instance ID of the gateway" }
-#     "/${local.stage_prefix}/${var.name}-backup-instance-id" = { value = aviatrix_gateway.avx_vpn_gw[0].peering_ha_cloud_instance_id
-#     description = "Instance ID of the backup gateway" }
-#     "/${local.stage_prefix}/${var.name}-dns-name" = { value = aws_route53_record.avx_vpn_gw[0].name,
-#     description = "DNS name of the Aviatrix VPN Gateway" }
-#     "/${local.stage_prefix}/${var.name}-dns-fqdn" = { value = aws_route53_record.avx_vpn_gw[0].fqdn
-#     description = "FQDN built using the zone domain and name" }
-#   }
-# }
+  write_parameters = {
+    "/${local.stage_prefix}/${var.name}-public-ip" = { value = aviatrix_gateway.avx_vpn_gw[0].eip,
+    description = "Public IP address of the Gateway created" }
+    "/${local.stage_prefix}/${var.name}-backup-public-ip" = { value = aviatrix_gateway.avx_vpn_gw[0].peering_ha_eip,
+    description = "Private IP address of the Gateway created" }
+    "/${local.stage_prefix}/${var.name}-public-dns-server" = { value = aviatrix_gateway.avx_vpn_gw[0].public_dns_server,
+    description = "DNS server used by the gateway. Default is `8.8.8.8`, can be overridden with the VPC's setting." }
+    "/${local.stage_prefix}/${var.name}-security-group-id" = { value = aviatrix_gateway.avx_vpn_gw[0].security_group_id,
+    description = "Security group used for the gateway" }
+    "/${local.stage_prefix}/${var.name}-instance-id" = { value = aviatrix_gateway.avx_vpn_gw[0].cloud_instance_id
+    description = "Instance ID of the gateway" }
+    "/${local.stage_prefix}/${var.name}-backup-instance-id" = { value = aviatrix_gateway.avx_vpn_gw[0].peering_ha_cloud_instance_id
+    description = "Instance ID of the backup gateway" }
+    "/${local.stage_prefix}/${var.name}-dns-name" = { value = aws_route53_record.avx_vpn_gw[0].name,
+    description = "DNS name of the Aviatrix VPN Gateway" }
+    "/${local.stage_prefix}/${var.name}-dns-fqdn" = { value = aws_route53_record.avx_vpn_gw[0].fqdn
+    description = "FQDN built using the zone domain and name" }
+  }
+}
 
 # Outputs
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades Terraform module/provider versions and changes what gets written to SSM/outputs, which can affect downstream consumers and apply behavior.
> 
> **Overview**
> **Upgrades module dependencies** by bumping the shared `aws/parameters` module from `0.32.0` to `0.56.4` across Aviatrix `accounts`, `controller`, and VPN modules, and tightening the `aviatrix` provider requirement to `>= 2.21.2` with an explicit source.
> 
> **Changes outputs/SSM publishing** by marking `output "aviatrix_accounts"` as `sensitive = true` and by re-enabling creation of SSM parameters for VPN gateway details (`vpn.tf`) and VPN profile name lists (`profiles.tf`) that were previously commented out.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b887f65a7b7a51ab3ee7f464764d36ed17afd42c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->